### PR TITLE
2章 認証機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 
 # External packages folder
 vendor/
+
+.keys.yaml

--- a/chapter2/chat/auth.go
+++ b/chapter2/chat/auth.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"net/http"
+	"strings"
 )
 
 type authHandler struct {
@@ -22,4 +25,19 @@ func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func MustAuth(handler http.Handler) http.Handler {
 	return &authHandler{next: handler}
+}
+
+// loginHandler handles the third-party login process.
+// format of path: /auth/{action}/{provider}
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	segs := strings.Split(r.URL.Path, "/")
+	action := segs[2]
+	provider := segs[3]
+	switch action {
+	case "login":
+		log.Println("TODO: ログイン処理 ", provider)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "アクション %s には非対応です", action)
+	}
 }

--- a/chapter2/chat/auth.go
+++ b/chapter2/chat/auth.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+)
+
+type authHandler struct {
+	next http.Handler
+}
+
+func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, err := r.Cookie("auth")
+	if err == http.ErrNoCookie {
+		w.Header().Set("Location", "/login")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	} else if err != nil {
+		panic(err.Error())
+	} else {
+		h.next.ServeHTTP(w, r)
+	}
+}
+
+func MustAuth(handler http.Handler) http.Handler {
+	return &authHandler{next: handler}
+}

--- a/chapter2/chat/auth.go
+++ b/chapter2/chat/auth.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/stretchr/gomniauth"
 )
 
 type authHandler struct {
@@ -35,7 +37,16 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 	provider := segs[3]
 	switch action {
 	case "login":
-		log.Println("TODO: ログイン処理 ", provider)
+		provider, err := gomniauth.Provider(provider)
+		if err != nil {
+			log.Fatalln("認証プロバイダーの取得に失敗しました: ", provider, "-", err)
+		}
+		loginUrl, err := provider.GetBeginAuthURL(nil, nil)
+		if err != nil {
+			log.Fatalln("GetBeginAuthURL の呼び出し中にエラーが発生しました: ", provider, "-", err)
+		}
+		w.Header().Set("Location", loginUrl)
+		w.WriteHeader(http.StatusTemporaryRedirect)
 	default:
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprintf(w, "アクション %s には非対応です", action)

--- a/chapter2/chat/auth.go
+++ b/chapter2/chat/auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/gomniauth"
+	"github.com/stretchr/objx"
 )
 
 type authHandler struct {
@@ -46,6 +47,29 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 			log.Fatalln("GetBeginAuthURL の呼び出し中にエラーが発生しました: ", provider, "-", err)
 		}
 		w.Header().Set("Location", loginUrl)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	case "callback":
+		provider, err := gomniauth.Provider(provider)
+		if err != nil {
+			log.Fatalln("認証プロバイダーの取得に失敗しました: ", provider, "-", err)
+		}
+		creds, err := provider.CompleteAuth(objx.MustFromURLQuery(r.URL.RawQuery))
+		if err != nil {
+			log.Fatalln("認証を完了できませんでした: ", provider, "-", err)
+		}
+		user, err := provider.GetUser(creds)
+		if err != nil {
+			log.Fatalln("ユーザーの取得に失敗しました: ", provider, "-", err)
+		}
+		authCookieValue := objx.New(map[string]interface{}{
+			"name": user.Name(),
+		}).MustBase64()
+		http.SetCookie(w, &http.Cookie{
+			Name:  "auth",
+			Value: authCookieValue,
+			Path:  "/",
+		})
+		w.Header()["Location"] = []string{"/chat"}
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	default:
 		w.WriteHeader(http.StatusNotFound)

--- a/chapter2/chat/client.go
+++ b/chapter2/chat/client.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/gorilla/websocket"
+)
+
+type client struct {
+	socket *websocket.Conn
+	send   chan []byte
+	room   *room
+}
+
+func (c *client) read() {
+	defer c.socket.Close()
+	for {
+		_, msg, err := c.socket.ReadMessage()
+		if err != nil {
+			return
+		}
+		c.room.forward <- msg
+	}
+}
+
+func (c *client) write() {
+	defer c.socket.Close()
+	for msg := range c.send {
+		err := c.socket.WriteMessage(websocket.TextMessage, msg)
+		if err != nil {
+			return
+		}
+	}
+}

--- a/chapter2/chat/client.go
+++ b/chapter2/chat/client.go
@@ -1,22 +1,28 @@
 package main
 
 import (
+	"time"
+
 	"github.com/gorilla/websocket"
 )
 
 type client struct {
-	socket *websocket.Conn
-	send   chan []byte
-	room   *room
+	socket   *websocket.Conn
+	send     chan *message
+	room     *room
+	userData map[string]interface{}
 }
 
 func (c *client) read() {
 	defer c.socket.Close()
 	for {
-		_, msg, err := c.socket.ReadMessage()
+		var msg *message
+		err := c.socket.ReadJSON(&msg)
 		if err != nil {
 			return
 		}
+		msg.When = time.Now()
+		msg.Name = c.userData["name"].(string)
 		c.room.forward <- msg
 	}
 }
@@ -24,7 +30,7 @@ func (c *client) read() {
 func (c *client) write() {
 	defer c.socket.Close()
 	for msg := range c.send {
-		err := c.socket.WriteMessage(websocket.TextMessage, msg)
+		err := c.socket.WriteJSON(msg)
 		if err != nil {
 			return
 		}

--- a/chapter2/chat/main.go
+++ b/chapter2/chat/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	r := newRoom()
 	r.tracer = trace.New(os.Stdout)
-	http.Handle("/", &templateHandler{filename: "chat.html"})
+	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
 	http.Handle("/room", r)
 
 	go r.run()

--- a/chapter2/chat/main.go
+++ b/chapter2/chat/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/gomniauth/providers/facebook"
 	"github.com/stretchr/gomniauth/providers/github"
 	"github.com/stretchr/gomniauth/providers/google"
+	"github.com/stretchr/objx"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,7 +38,16 @@ func (t *templateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		t.templ =
 			template.Must(template.ParseFiles(filepath.Join("templates", t.filename)))
 	})
-	err := t.templ.Execute(w, r)
+
+	data := map[string]interface{}{
+		"Host": r.Host,
+	}
+	authCookie, err := r.Cookie("auth")
+	if err == nil {
+		data["UserData"] = objx.MustFromBase64(authCookie.Value)
+	}
+
+	err = t.templ.Execute(w, data)
 	if err != nil {
 		log.Fatal("ServeHTTP: ", err)
 	}

--- a/chapter2/chat/main.go
+++ b/chapter2/chat/main.go
@@ -35,6 +35,7 @@ func main() {
 	r := newRoom()
 	r.tracer = trace.New(os.Stdout)
 	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
+	http.Handle("/login", &templateHandler{filename: "login.html"})
 	http.Handle("/room", r)
 
 	go r.run()

--- a/chapter2/chat/main.go
+++ b/chapter2/chat/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"../../chapter1/trace"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"text/template"
+)
+
+type templateHandler struct {
+	once     sync.Once
+	filename string
+	templ    *template.Template
+}
+
+func (t *templateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.once.Do(func() {
+		t.templ =
+			template.Must(template.ParseFiles(filepath.Join("templates", t.filename)))
+	})
+	err := t.templ.Execute(w, r)
+	if err != nil {
+		log.Fatal("ServeHTTP: ", err)
+	}
+}
+
+func main() {
+	var addr = flag.String("addr", ":8080", "アプリケーションのアドレス")
+	flag.Parse()
+
+	r := newRoom()
+	r.tracer = trace.New(os.Stdout)
+	http.Handle("/", &templateHandler{filename: "chat.html"})
+	http.Handle("/room", r)
+
+	go r.run()
+	log.Println("Webサーバーを開始します。ポート: ", *addr)
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal("ListenAndServe:", err)
+	}
+}

--- a/chapter2/chat/main.go
+++ b/chapter2/chat/main.go
@@ -36,6 +36,7 @@ func main() {
 	r.tracer = trace.New(os.Stdout)
 	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
 	http.Handle("/login", &templateHandler{filename: "login.html"})
+	http.HandleFunc("/auth/", loginHandler)
 	http.Handle("/room", r)
 
 	go r.run()

--- a/chapter2/chat/message.go
+++ b/chapter2/chat/message.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"time"
+)
+
+type message struct {
+	Name    string
+	Message string
+	When    time.Time
+}

--- a/chapter2/chat/room.go
+++ b/chapter2/chat/room.go
@@ -6,10 +6,11 @@ import (
 
 	"../../chapter1/trace"
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/objx"
 )
 
 type room struct {
-	forward chan []byte
+	forward chan *message
 	join    chan *client
 	leave   chan *client
 	clients map[*client]bool
@@ -18,7 +19,7 @@ type room struct {
 
 func newRoom() *room {
 	return &room{
-		forward: make(chan []byte),
+		forward: make(chan *message),
 		join:    make(chan *client),
 		leave:   make(chan *client),
 		clients: make(map[*client]bool),
@@ -36,7 +37,7 @@ func (r *room) run() {
 			close(client.send)
 			r.tracer.Trace("クライアントが退室しました")
 		case msg := <-r.forward:
-			r.tracer.Trace("メッセージを受信しました: ", string(msg))
+			r.tracer.Trace("メッセージを受信しました: ", msg.Message)
 			for client := range r.clients {
 				select {
 				case client.send <- msg:
@@ -68,11 +69,20 @@ func (r *room) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		log.Fatal("ServeHTTP:", err)
 		return
 	}
-	client := &client{
-		socket: socket,
-		send:   make(chan []byte, messageBufferSize),
-		room:   r,
+
+	authCookie, err := req.Cookie("auth")
+	if err != nil {
+		log.Fatal("クッキーの取得に失敗しました: ", err)
+		return
 	}
+
+	client := &client{
+		socket:   socket,
+		send:     make(chan *message, messageBufferSize),
+		room:     r,
+		userData: objx.MustFromBase64(authCookie.Value),
+	}
+
 	r.join <- client
 	defer func() { r.leave <- client }()
 	go client.write()

--- a/chapter2/chat/room.go
+++ b/chapter2/chat/room.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"../../chapter1/trace"
+	"github.com/gorilla/websocket"
+)
+
+type room struct {
+	forward chan []byte
+	join    chan *client
+	leave   chan *client
+	clients map[*client]bool
+	tracer  trace.Tracer
+}
+
+func newRoom() *room {
+	return &room{
+		forward: make(chan []byte),
+		join:    make(chan *client),
+		leave:   make(chan *client),
+		clients: make(map[*client]bool),
+	}
+}
+
+func (r *room) run() {
+	for {
+		select {
+		case client := <-r.join:
+			r.clients[client] = true
+			r.tracer.Trace("新しいクライアントが参加しました")
+		case client := <-r.leave:
+			delete(r.clients, client)
+			close(client.send)
+			r.tracer.Trace("クライアントが退室しました")
+		case msg := <-r.forward:
+			r.tracer.Trace("メッセージを受信しました: ", string(msg))
+			for client := range r.clients {
+				select {
+				case client.send <- msg:
+					r.tracer.Trace(" -- クライアントに送信されました")
+				default:
+					// Failed to send message
+					delete(r.clients, client)
+					close(client.send)
+					r.tracer.Trace(" -- 送信に失敗しました。クライアントをクリーンアップします")
+				}
+			}
+		}
+	}
+}
+
+const (
+	socketBufferSize  = 1024
+	messageBufferSize = 256
+)
+
+var upgrader = &websocket.Upgrader{
+	ReadBufferSize:  socketBufferSize,
+	WriteBufferSize: socketBufferSize,
+}
+
+func (r *room) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	socket, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		log.Fatal("ServeHTTP:", err)
+		return
+	}
+	client := &client{
+		socket: socket,
+		send:   make(chan []byte, messageBufferSize),
+		room:   r,
+	}
+	r.join <- client
+	defer func() { r.leave <- client }()
+	go client.write()
+	client.read()
+}

--- a/chapter2/chat/templates/chat.html
+++ b/chapter2/chat/templates/chat.html
@@ -26,7 +26,7 @@
             alert("エラー : WebSocket接続が行われていません。");
             return false;
           }
-          socket.send(msgBox.val());
+          socket.send(JSON.stringify({"Message": msgBox.val()}));
           msgBox.val("");
           return false;
         });
@@ -38,7 +38,13 @@
             alert("接続が終了しました。");
           }
           socket.onmessage = function(e) {
-            messages.append($("<li>").text(e.data));
+            var msg = JSON.parse(e.data);
+            messages.append(
+              $("<li>").append(
+                $("<strong>").text(msg.Name + ": "),
+                $("<span>").text(msg.Message)
+              )
+            );
           }
         }
       })

--- a/chapter2/chat/templates/chat.html
+++ b/chapter2/chat/templates/chat.html
@@ -10,6 +10,7 @@
     <ul id="messages"></ul>
     WebSocket を使ったチャットアプリケーション
     <form id="chatbox">
+      {{.UserData.name}}:<br/>
       <textarea></textarea>
       <input type="submit" value="送信" />
     </form>

--- a/chapter2/chat/templates/chat.html
+++ b/chapter2/chat/templates/chat.html
@@ -1,0 +1,46 @@
+<html>
+  <head>
+    <title>チャット</title>
+    <style>
+      input { display: block; }
+      ul { list-style: none; }
+    </style>
+  </head>
+  <body>
+    <ul id="messages"></ul>
+    WebSocket を使ったチャットアプリケーション
+    <form id="chatbox">
+      <textarea></textarea>
+      <input type="submit" value="送信" />
+    </form>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script>
+      $(function(){
+        var socket = null;
+        var msgBox = $("#chatbox textarea");
+        var messages = $("#messages");
+        $("#chatbox").submit(function(){
+          if (!msgBox.val()) return false;
+          if (!socket) {
+            alert("エラー : WebSocket接続が行われていません。");
+            return false;
+          }
+          socket.send(msgBox.val());
+          msgBox.val("");
+          return false;
+        });
+        if (!window["WebSocket"]) {
+          alert("エラー : WebSocket に対応していないブラウザです。")
+        } else {
+          socket = new WebSocket("ws://{{.Host}}/room");
+          socket.onclose = function() {
+            alert("接続が終了しました。");
+          }
+          socket.onmessage = function(e) {
+            messages.append($("<li>").text(e.data));
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/chapter2/chat/templates/login.html
+++ b/chapter2/chat/templates/login.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>ログイン</title>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container">
+      <div class="page-header">
+        <h1>サインインしてください</h1>
+      </div>
+      <div class="panel panel-danger">
+        <div class="panel-heading">
+          <h3 class="panel-title">チャットを行うにはサインインが必要です</h3>
+        </div>
+        <div class="panel-body">
+          <p>サインインに使用するサービスを選んでください:</p>
+          <ul>
+            <li><a href="/auth/login/facebook">Facebook</a></li>
+            <li><a href="/auth/login/github">GitHub</a></li>
+            <li><a href="/auth/login/google">Google</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
やること

- [Decorator パターン](http://www.techscore.com/tech/DesignPattern/Decorator.html/)に基づいて [`Http.Handler` 型](https://golang.org/pkg/net/http/#Handler) をラップし、機能を追加
- 動的なパスで HTTP のエンドポイント (端点) を提供する
- オープンソースの [Gomniauth](https://github.com/stretchr/gomniauth) プロジェクトを利用して認証サービスにアクセスする
- `http` パッケージを使ってクッキーの読み書きを行う
- Base64 形式を使ってオブジェクトのエンコードと復元を行う
- WebSocket 上で JSON データを送受信する
- 自分で定義した型のチャネルを定義して利用する