### PR TITLE
3章 プロフィール画像を追加する3つの方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _testmain.go
 vendor/
 
 .keys.yaml
+*/*/avatars/

--- a/chapter3/chat/auth.go
+++ b/chapter3/chat/auth.go
@@ -64,6 +64,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		authCookieValue := objx.New(map[string]interface{}{
 			"name":       user.Name(),
 			"avatar_url": user.AvatarURL(),
+			"email":      user.Email(),
 		}).MustBase64()
 		http.SetCookie(w, &http.Cookie{
 			Name:  "auth",

--- a/chapter3/chat/auth.go
+++ b/chapter3/chat/auth.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/md5"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -61,7 +63,11 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Fatalln("ユーザーの取得に失敗しました: ", provider, "-", err)
 		}
+		m := md5.New()
+		io.WriteString(m, strings.ToLower(user.Name()))
+		userID := fmt.Sprintf("%x", m.Sum(nil))
 		authCookieValue := objx.New(map[string]interface{}{
+			"userid":     userID,
 			"name":       user.Name(),
 			"avatar_url": user.AvatarURL(),
 			"email":      user.Email(),

--- a/chapter3/chat/auth.go
+++ b/chapter3/chat/auth.go
@@ -15,8 +15,8 @@ type authHandler struct {
 }
 
 func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	_, err := r.Cookie("auth")
-	if err == http.ErrNoCookie {
+	cookie, err := r.Cookie("auth")
+	if err == http.ErrNoCookie || cookie.Value == "" {
 		w.Header().Set("Location", "/login")
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	} else if err != nil {

--- a/chapter3/chat/auth.go
+++ b/chapter3/chat/auth.go
@@ -12,6 +12,22 @@ import (
 	"github.com/stretchr/objx"
 )
 
+import gomniauthcommon "github.com/stretchr/gomniauth/common"
+
+type ChatUser interface {
+	UniqueID() string
+	AvatarURL() string
+}
+
+type chatUser struct {
+	gomniauthcommon.User
+	uniqueID string
+}
+
+func (u chatUser) UniqueID() string {
+	return u.uniqueID
+}
+
 type authHandler struct {
 	next http.Handler
 }
@@ -63,13 +79,20 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Fatalln("ユーザーの取得に失敗しました: ", provider, "-", err)
 		}
+
+		chatUser := &chatUser{User: user}
 		m := md5.New()
 		io.WriteString(m, strings.ToLower(user.Name()))
-		userID := fmt.Sprintf("%x", m.Sum(nil))
+		chatUser.uniqueID = fmt.Sprintf("%x", m.Sum(nil))
+		avatarURL, err := avatars.GetAvatarURL(chatUser)
+		if err != nil {
+			log.Fatalln("GetAvatarURL に失敗しました", "-", err)
+		}
+
 		authCookieValue := objx.New(map[string]interface{}{
-			"userid":     userID,
+			"userid":     chatUser.uniqueID,
 			"name":       user.Name(),
-			"avatar_url": user.AvatarURL(),
+			"avatar_url": avatarURL,
 			"email":      user.Email(),
 		}).MustBase64()
 		http.SetCookie(w, &http.Cookie{

--- a/chapter3/chat/auth.go
+++ b/chapter3/chat/auth.go
@@ -62,7 +62,8 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 			log.Fatalln("ユーザーの取得に失敗しました: ", provider, "-", err)
 		}
 		authCookieValue := objx.New(map[string]interface{}{
-			"name": user.Name(),
+			"name":       user.Name(),
+			"avatar_url": user.AvatarURL(),
 		}).MustBase64()
 		http.SetCookie(w, &http.Cookie{
 			Name:  "auth",

--- a/chapter3/chat/auth.go
+++ b/chapter3/chat/auth.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/stretchr/gomniauth"
+	"github.com/stretchr/objx"
+)
+
+type authHandler struct {
+	next http.Handler
+}
+
+func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, err := r.Cookie("auth")
+	if err == http.ErrNoCookie {
+		w.Header().Set("Location", "/login")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	} else if err != nil {
+		panic(err.Error())
+	} else {
+		h.next.ServeHTTP(w, r)
+	}
+}
+
+func MustAuth(handler http.Handler) http.Handler {
+	return &authHandler{next: handler}
+}
+
+// loginHandler handles the third-party login process.
+// format of path: /auth/{action}/{provider}
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	segs := strings.Split(r.URL.Path, "/")
+	action := segs[2]
+	provider := segs[3]
+	switch action {
+	case "login":
+		provider, err := gomniauth.Provider(provider)
+		if err != nil {
+			log.Fatalln("認証プロバイダーの取得に失敗しました: ", provider, "-", err)
+		}
+		loginUrl, err := provider.GetBeginAuthURL(nil, nil)
+		if err != nil {
+			log.Fatalln("GetBeginAuthURL の呼び出し中にエラーが発生しました: ", provider, "-", err)
+		}
+		w.Header().Set("Location", loginUrl)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	case "callback":
+		provider, err := gomniauth.Provider(provider)
+		if err != nil {
+			log.Fatalln("認証プロバイダーの取得に失敗しました: ", provider, "-", err)
+		}
+		creds, err := provider.CompleteAuth(objx.MustFromURLQuery(r.URL.RawQuery))
+		if err != nil {
+			log.Fatalln("認証を完了できませんでした: ", provider, "-", err)
+		}
+		user, err := provider.GetUser(creds)
+		if err != nil {
+			log.Fatalln("ユーザーの取得に失敗しました: ", provider, "-", err)
+		}
+		authCookieValue := objx.New(map[string]interface{}{
+			"name": user.Name(),
+		}).MustBase64()
+		http.SetCookie(w, &http.Cookie{
+			Name:  "auth",
+			Value: authCookieValue,
+			Path:  "/",
+		})
+		w.Header()["Location"] = []string{"/chat"}
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "アクション %s には非対応です", action)
+	}
+}

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -41,3 +41,18 @@ func (_ GravatarAvatar) GetAvatarURL(c *client) (string, error) {
 	}
 	return "", ErrNoAvatarURL
 }
+
+type FileSystemAvatar struct{}
+
+var UseFileSystemAvatar FileSystemAvatar
+
+func (_ FileSystemAvatar) GetAvatarURL(c *client) (string, error) {
+	userid, ok := c.userData["userid"]
+	if ok {
+		useridStr, ok := userid.(string)
+		if ok {
+			return "/avatars/" + useridStr + ".jpg", nil
+		}
+	}
+	return "", ErrNoAvatarURL
+}

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"io/ioutil"
+	"path/filepath"
 )
 
 // ErrNoAvatarURL is the error that is returned when the
@@ -51,7 +53,18 @@ func (_ FileSystemAvatar) GetAvatarURL(c *client) (string, error) {
 	if ok {
 		useridStr, ok := userid.(string)
 		if ok {
-			return "/avatars/" + useridStr + ".jpg", nil
+			files, err := ioutil.ReadDir("avatars")
+			if err == nil {
+				for _, file := range files {
+					if file.IsDir() {
+						continue
+					}
+					match, _ := filepath.Match(useridStr+".*", file.Name())
+					if match {
+						return "/avatars/" + file.Name(), nil
+					}
+				}
+			}
 		}
 	}
 	return "", ErrNoAvatarURL

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -53,3 +53,15 @@ func (_ FileSystemAvatar) GetAvatarURL(u ChatUser) (string, error) {
 	}
 	return "", ErrNoAvatarURL
 }
+
+type TryAvatars []Avatar
+
+func (a TryAvatars) GetAvatarURL(u ChatUser) (string, error) {
+	for _, avatar := range a {
+		url, err := avatar.GetAvatarURL(u)
+		if err == nil {
+			return url, nil
+		}
+	}
+	return "", ErrNoAvatarURL
+}

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"errors"
+)
+
+// ErrNoAvatarURL is the error that is returned when the
+// Avatar instance is unable to provide an avatar URL.
+var ErrNoAvatarURL = errors.New("chat: Unable to get an avatar URL")
+
+type Avatar interface {
+	GetAvatarURL(c *client) (string, error)
+}
+
+type AuthAvatar struct{}
+
+var UseAuthAvatar AuthAvatar
+
+func (_ AuthAvatar) GetAvatarURL(c *client) (string, error) {
+	url, ok := c.userData["avatar_url"]
+	if ok {
+		urlStr, ok := url.(string)
+		if ok {
+			return urlStr, nil
+		}
+	}
+	return "", ErrNoAvatarURL
+}

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
 	"path/filepath"
 )
 
@@ -39,19 +38,11 @@ type FileSystemAvatar struct{}
 var UseFileSystemAvatar FileSystemAvatar
 
 func (_ FileSystemAvatar) GetAvatarURL(u ChatUser) (string, error) {
-	files, err := ioutil.ReadDir("avatars")
-	if err == nil {
-		for _, file := range files {
-			if file.IsDir() {
-				continue
-			}
-			match, _ := filepath.Match(u.UniqueID()+".*", file.Name())
-			if match {
-				return "/avatars/" + file.Name(), nil
-			}
-		}
+	matches, err := filepath.Glob(filepath.Join("avatars", u.UniqueID()+".*"))
+	if err != nil || len(matches) == 0 {
+		return "", ErrNoAvatarURL
 	}
-	return "", ErrNoAvatarURL
+	return "/" + filepath.ToSlash(matches[0]), nil
 }
 
 type TryAvatars []Avatar

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"crypto/md5"
 	"errors"
+	"fmt"
+	"io"
+	"strings"
 )
 
 // ErrNoAvatarURL is the error that is returned when the
@@ -22,6 +26,23 @@ func (_ AuthAvatar) GetAvatarURL(c *client) (string, error) {
 		urlStr, ok := url.(string)
 		if ok {
 			return urlStr, nil
+		}
+	}
+	return "", ErrNoAvatarURL
+}
+
+type GravatarAvatar struct{}
+
+var UseGravatar GravatarAvatar
+
+func (_ GravatarAvatar) GetAvatarURL(c *client) (string, error) {
+	email, ok := c.userData["email"]
+	if ok {
+		emailStr, ok := email.(string)
+		if ok {
+			m := md5.New()
+			io.WriteString(m, strings.ToLower(emailStr))
+			return fmt.Sprintf("//www.gravatar.com/avatar/%x", m.Sum(nil)), nil
 		}
 	}
 	return "", ErrNoAvatarURL

--- a/chapter3/chat/avatar.go
+++ b/chapter3/chat/avatar.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"crypto/md5"
 	"errors"
-	"fmt"
-	"io"
-	"strings"
 )
 
 // ErrNoAvatarURL is the error that is returned when the
@@ -36,13 +32,11 @@ type GravatarAvatar struct{}
 var UseGravatar GravatarAvatar
 
 func (_ GravatarAvatar) GetAvatarURL(c *client) (string, error) {
-	email, ok := c.userData["email"]
+	userid, ok := c.userData["userid"]
 	if ok {
-		emailStr, ok := email.(string)
+		useridStr, ok := userid.(string)
 		if ok {
-			m := md5.New()
-			io.WriteString(m, strings.ToLower(emailStr))
-			return fmt.Sprintf("//www.gravatar.com/avatar/%x", m.Sum(nil)), nil
+			return "//www.gravatar.com/avatar/" + useridStr, nil
 		}
 	}
 	return "", ErrNoAvatarURL

--- a/chapter3/chat/avatar_test.go
+++ b/chapter3/chat/avatar_test.go
@@ -7,18 +7,24 @@ import (
 	"testing"
 )
 
+import gomniauthtest "github.com/stretchr/gomniauth/test"
+
 func TestAuthAvatar(t *testing.T) {
 	var authAvatar AuthAvatar
-	client := new(client)
-	url, err := authAvatar.GetAvatarURL(client)
+	testUser := &gomniauthtest.TestUser{}
+	testUser.On("AvatarURL").Return("", ErrNoAvatarURL)
+	testChatUser := &chatUser{User: testUser}
+	url, err := authAvatar.GetAvatarURL(testChatUser)
 	if err != ErrNoAvatarURL {
 		t.Error("値が存在しない場合、",
 			"AuthAvatar.GetAvatarURL は ErrNoAvatarURL を返すべきです")
 	}
 
 	testUrl := "http://url-to-avatar"
-	client.userData = map[string]interface{}{"avatar_url": testUrl}
-	url, err = authAvatar.GetAvatarURL(client)
+	testUser = &gomniauthtest.TestUser{}
+	testUser.On("AvatarURL").Return(testUrl, ErrNoAvatarURL)
+	testChatUser.User = testUser
+	url, err = authAvatar.GetAvatarURL(testChatUser)
 	if err != nil {
 		t.Error("値が存在する場合、",
 			"AuthAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)
@@ -31,13 +37,12 @@ func TestAuthAvatar(t *testing.T) {
 
 func TestGravatarAvatar(t *testing.T) {
 	var gravatarAvatar GravatarAvatar
-	client := new(client)
-	client.userData = map[string]interface{}{"userid": "0bc83cb571cd1c50ba6f3e8a78ef1346"}
-	url, err := gravatarAvatar.GetAvatarURL(client)
+	user := &chatUser{uniqueID: "abc"}
+	url, err := gravatarAvatar.GetAvatarURL(user)
 	if err != nil {
 		t.Error("GravatarAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)
 	}
-	if url != "//www.gravatar.com/avatar/0bc83cb571cd1c50ba6f3e8a78ef1346" {
+	if url != "//www.gravatar.com/avatar/abc" {
 		t.Errorf("GravatarAvatar.GetAvatarURL が %s という誤った値を返しました", url)
 	}
 }
@@ -48,9 +53,8 @@ func TestFileSystemAvatar(t *testing.T) {
 	defer func() { os.Remove(filename) }()
 
 	var fileSystemAvatar FileSystemAvatar
-	client := new(client)
-	client.userData = map[string]interface{}{"userid": "abc"}
-	url, err := fileSystemAvatar.GetAvatarURL(client)
+	user := &chatUser{uniqueID: "abc"}
+	url, err := fileSystemAvatar.GetAvatarURL(user)
 	if err != nil {
 		t.Error("FileSystemAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)
 	}

--- a/chapter3/chat/avatar_test.go
+++ b/chapter3/chat/avatar_test.go
@@ -29,7 +29,7 @@ func TestAuthAvatar(t *testing.T) {
 func TestGravatarAvatar(t *testing.T) {
 	var gravatarAvatar GravatarAvatar
 	client := new(client)
-	client.userData = map[string]interface{}{"email": "MyEmailAddress@example.com"}
+	client.userData = map[string]interface{}{"userid": "0bc83cb571cd1c50ba6f3e8a78ef1346"}
 	url, err := gravatarAvatar.GetAvatarURL(client)
 	if err != nil {
 		t.Error("GravatarAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)

--- a/chapter3/chat/avatar_test.go
+++ b/chapter3/chat/avatar_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestAuthAvatar(t *testing.T) {
+	var authAvatar AuthAvatar
+	client := new(client)
+	url, err := authAvatar.GetAvatarURL(client)
+	if err != ErrNoAvatarURL {
+		t.Error("値が存在しない場合、",
+			"AuthAvatar.GetAvatarURL は ErrNoAvatarURL を返すべきです")
+	}
+
+	testUrl := "http://url-to-avatar"
+	client.userData = map[string]interface{}{"avatar_url": testUrl}
+	url, err = authAvatar.GetAvatarURL(client)
+	if err != nil {
+		t.Error("値が存在する場合、",
+			"AuthAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)
+	} else {
+		if url != testUrl {
+			t.Error("AuthAvatar.GetAvatarURL は正しいURLを返すべきです: ", url)
+		}
+	}
+}

--- a/chapter3/chat/avatar_test.go
+++ b/chapter3/chat/avatar_test.go
@@ -25,3 +25,16 @@ func TestAuthAvatar(t *testing.T) {
 		}
 	}
 }
+
+func TestGravatarAvatar(t *testing.T) {
+	var gravatarAvatar GravatarAvatar
+	client := new(client)
+	client.userData = map[string]interface{}{"email": "MyEmailAddress@example.com"}
+	url, err := gravatarAvatar.GetAvatarURL(client)
+	if err != nil {
+		t.Error("GravatarAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)
+	}
+	if url != "//www.gravatar.com/avatar/0bc83cb571cd1c50ba6f3e8a78ef1346" {
+		t.Errorf("GravatarAvatar.GetAvatarURL が %s という誤った値を返しました", url)
+	}
+}

--- a/chapter3/chat/avatar_test.go
+++ b/chapter3/chat/avatar_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -36,5 +39,22 @@ func TestGravatarAvatar(t *testing.T) {
 	}
 	if url != "//www.gravatar.com/avatar/0bc83cb571cd1c50ba6f3e8a78ef1346" {
 		t.Errorf("GravatarAvatar.GetAvatarURL が %s という誤った値を返しました", url)
+	}
+}
+
+func TestFileSystemAvatar(t *testing.T) {
+	filename := filepath.Join("avatars", "abc.jpg")
+	ioutil.WriteFile(filename, []byte{}, 0777)
+	defer func() { os.Remove(filename) }()
+
+	var fileSystemAvatar FileSystemAvatar
+	client := new(client)
+	client.userData = map[string]interface{}{"userid": "abc"}
+	url, err := fileSystemAvatar.GetAvatarURL(client)
+	if err != nil {
+		t.Error("FileSystemAvatar.GetAvatarURL はエラーを返すべきではありません: ", err)
+	}
+	if url != "/avatars/abc.jpg" {
+		t.Errorf("FileSystemAvatar.GetAvatarURL が %s という誤った値を返しました", url)
 	}
 }

--- a/chapter3/chat/client.go
+++ b/chapter3/chat/client.go
@@ -23,6 +23,10 @@ func (c *client) read() {
 		}
 		msg.When = time.Now()
 		msg.Name = c.userData["name"].(string)
+		avatarURL, ok := c.userData["avatar_url"]
+		if ok {
+			msg.AvatarURL = avatarURL.(string)
+		}
 		c.room.forward <- msg
 	}
 }

--- a/chapter3/chat/client.go
+++ b/chapter3/chat/client.go
@@ -23,10 +23,7 @@ func (c *client) read() {
 		}
 		msg.When = time.Now()
 		msg.Name = c.userData["name"].(string)
-		avatarURL, ok := c.userData["avatar_url"]
-		if ok {
-			msg.AvatarURL = avatarURL.(string)
-		}
+		msg.AvatarURL, _ = c.room.avatar.GetAvatarURL(c)
 		c.room.forward <- msg
 	}
 }

--- a/chapter3/chat/client.go
+++ b/chapter3/chat/client.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type client struct {
+	socket   *websocket.Conn
+	send     chan *message
+	room     *room
+	userData map[string]interface{}
+}
+
+func (c *client) read() {
+	defer c.socket.Close()
+	for {
+		var msg *message
+		err := c.socket.ReadJSON(&msg)
+		if err != nil {
+			return
+		}
+		msg.When = time.Now()
+		msg.Name = c.userData["name"].(string)
+		c.room.forward <- msg
+	}
+}
+
+func (c *client) write() {
+	defer c.socket.Close()
+	for msg := range c.send {
+		err := c.socket.WriteJSON(msg)
+		if err != nil {
+			return
+		}
+	}
+}

--- a/chapter3/chat/client.go
+++ b/chapter3/chat/client.go
@@ -23,7 +23,10 @@ func (c *client) read() {
 		}
 		msg.When = time.Now()
 		msg.Name = c.userData["name"].(string)
-		msg.AvatarURL, _ = c.room.avatar.GetAvatarURL(c)
+		avatarURL, ok := c.userData["avatar_url"]
+		if ok {
+			msg.AvatarURL = avatarURL.(string)
+		}
 		c.room.forward <- msg
 	}
 }

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -74,7 +74,7 @@ func main() {
 		google.New(keys.OauthServices["google"].ClientId, keys.OauthServices["google"].SecretKey, "http://localhost:8080/auth/callback/google"),
 	)
 
-	r := newRoom(UseGravatar)
+	r := newRoom(UseFileSystemAvatar)
 	r.tracer = trace.New(os.Stdout)
 	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
 	http.Handle("/login", &templateHandler{filename: "login.html"})
@@ -92,6 +92,8 @@ func main() {
 	})
 	http.Handle("/upload", &templateHandler{filename: "upload.html"})
 	http.HandleFunc("/uploader", uploaderHandler)
+	http.Handle("/avatars/",
+		http.StripPrefix("/avatars/", http.FileServer(http.Dir("./avatars"))))
 
 	go r.run()
 	log.Println("Webサーバーを開始します。ポート: ", *addr)

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -80,6 +80,16 @@ func main() {
 	http.Handle("/login", &templateHandler{filename: "login.html"})
 	http.HandleFunc("/auth/", loginHandler)
 	http.Handle("/room", r)
+	http.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:   "auth",
+			Value:  "",
+			Path:   "/",
+			MaxAge: -1,
+		})
+		w.Header()["Location"] = []string{"/chat"}
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	})
 
 	go r.run()
 	log.Println("Webサーバーを開始します。ポート: ", *addr)

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -74,7 +74,7 @@ func main() {
 		google.New(keys.OauthServices["google"].ClientId, keys.OauthServices["google"].SecretKey, "http://localhost:8080/auth/callback/google"),
 	)
 
-	r := newRoom()
+	r := newRoom(UseAuthAvatar)
 	r.tracer = trace.New(os.Stdout)
 	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
 	http.Handle("/login", &templateHandler{filename: "login.html"})

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -19,6 +19,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var avatars Avatar = UseFileSystemAvatar
+
 type templateHandler struct {
 	once     sync.Once
 	filename string
@@ -74,7 +76,7 @@ func main() {
 		google.New(keys.OauthServices["google"].ClientId, keys.OauthServices["google"].SecretKey, "http://localhost:8080/auth/callback/google"),
 	)
 
-	r := newRoom(UseFileSystemAvatar)
+	r := newRoom()
 	r.tracer = trace.New(os.Stdout)
 	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
 	http.Handle("/login", &templateHandler{filename: "login.html"})

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -19,7 +19,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var avatars Avatar = UseFileSystemAvatar
+var avatars TryAvatars = TryAvatars{
+	UseFileSystemAvatar,
+	UseAuthAvatar,
+	UseGravatar,
+}
 
 type templateHandler struct {
 	once     sync.Once

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -90,6 +90,8 @@ func main() {
 		w.Header()["Location"] = []string{"/chat"}
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	})
+	http.Handle("/upload", &templateHandler{filename: "upload.html"})
+	http.HandleFunc("/uploader", uploaderHandler)
 
 	go r.run()
 	log.Println("Webサーバーを開始します。ポート: ", *addr)

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"../../chapter1/trace"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"text/template"
+
+	"github.com/stretchr/gomniauth"
+	"github.com/stretchr/gomniauth/providers/facebook"
+	"github.com/stretchr/gomniauth/providers/github"
+	"github.com/stretchr/gomniauth/providers/google"
+	"github.com/stretchr/objx"
+	"gopkg.in/yaml.v2"
+)
+
+type templateHandler struct {
+	once     sync.Once
+	filename string
+	templ    *template.Template
+}
+
+type Keys struct {
+	SecurityKey   string `yaml:"securityKey"`
+	OauthServices map[string]struct {
+		ClientId  string `yaml:"id"`
+		SecretKey string `yaml:"secret"`
+	} `yaml:"oauthServices"`
+}
+
+func (t *templateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.once.Do(func() {
+		t.templ =
+			template.Must(template.ParseFiles(filepath.Join("templates", t.filename)))
+	})
+
+	data := map[string]interface{}{
+		"Host": r.Host,
+	}
+	authCookie, err := r.Cookie("auth")
+	if err == nil {
+		data["UserData"] = objx.MustFromBase64(authCookie.Value)
+	}
+
+	err = t.templ.Execute(w, data)
+	if err != nil {
+		log.Fatal("ServeHTTP: ", err)
+	}
+}
+
+func main() {
+	var addr = flag.String("addr", ":8080", "アプリケーションのアドレス")
+	flag.Parse()
+
+	buf, err := ioutil.ReadFile(".keys.yaml")
+	if err != nil {
+		log.Fatal("keys.yaml is not found.")
+	}
+	keys := Keys{}
+	err = yaml.Unmarshal(buf, &keys)
+	if err != nil {
+		log.Fatal("error Unmarshal: ", buf)
+	}
+
+	gomniauth.SetSecurityKey(keys.SecurityKey)
+	gomniauth.WithProviders(
+		facebook.New(keys.OauthServices["facebook"].ClientId, keys.OauthServices["facebook"].SecretKey, "http://localhost:8080/auth/callback/facebook"),
+		github.New(keys.OauthServices["github"].ClientId, keys.OauthServices["github"].SecretKey, "http://localhost:8080/auth/callback/github"),
+		google.New(keys.OauthServices["google"].ClientId, keys.OauthServices["google"].SecretKey, "http://localhost:8080/auth/callback/google"),
+	)
+
+	r := newRoom()
+	r.tracer = trace.New(os.Stdout)
+	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
+	http.Handle("/login", &templateHandler{filename: "login.html"})
+	http.HandleFunc("/auth/", loginHandler)
+	http.Handle("/room", r)
+
+	go r.run()
+	log.Println("Webサーバーを開始します。ポート: ", *addr)
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal("ListenAndServe:", err)
+	}
+}

--- a/chapter3/chat/main.go
+++ b/chapter3/chat/main.go
@@ -74,7 +74,7 @@ func main() {
 		google.New(keys.OauthServices["google"].ClientId, keys.OauthServices["google"].SecretKey, "http://localhost:8080/auth/callback/google"),
 	)
 
-	r := newRoom(UseAuthAvatar)
+	r := newRoom(UseGravatar)
 	r.tracer = trace.New(os.Stdout)
 	http.Handle("/chat", MustAuth(&templateHandler{filename: "chat.html"}))
 	http.Handle("/login", &templateHandler{filename: "login.html"})

--- a/chapter3/chat/message.go
+++ b/chapter3/chat/message.go
@@ -5,7 +5,8 @@ import (
 )
 
 type message struct {
-	Name    string
-	Message string
-	When    time.Time
+	Name      string
+	Message   string
+	When      time.Time
+	AvatarURL string
 }

--- a/chapter3/chat/message.go
+++ b/chapter3/chat/message.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"time"
+)
+
+type message struct {
+	Name    string
+	Message string
+	When    time.Time
+}

--- a/chapter3/chat/room.go
+++ b/chapter3/chat/room.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"../../chapter1/trace"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/objx"
+)
+
+type room struct {
+	forward chan *message
+	join    chan *client
+	leave   chan *client
+	clients map[*client]bool
+	tracer  trace.Tracer
+}
+
+func newRoom() *room {
+	return &room{
+		forward: make(chan *message),
+		join:    make(chan *client),
+		leave:   make(chan *client),
+		clients: make(map[*client]bool),
+	}
+}
+
+func (r *room) run() {
+	for {
+		select {
+		case client := <-r.join:
+			r.clients[client] = true
+			r.tracer.Trace("新しいクライアントが参加しました")
+		case client := <-r.leave:
+			delete(r.clients, client)
+			close(client.send)
+			r.tracer.Trace("クライアントが退室しました")
+		case msg := <-r.forward:
+			r.tracer.Trace("メッセージを受信しました: ", msg.Message)
+			for client := range r.clients {
+				select {
+				case client.send <- msg:
+					r.tracer.Trace(" -- クライアントに送信されました")
+				default:
+					// Failed to send message
+					delete(r.clients, client)
+					close(client.send)
+					r.tracer.Trace(" -- 送信に失敗しました。クライアントをクリーンアップします")
+				}
+			}
+		}
+	}
+}
+
+const (
+	socketBufferSize  = 1024
+	messageBufferSize = 256
+)
+
+var upgrader = &websocket.Upgrader{
+	ReadBufferSize:  socketBufferSize,
+	WriteBufferSize: socketBufferSize,
+}
+
+func (r *room) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	socket, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		log.Fatal("ServeHTTP:", err)
+		return
+	}
+
+	authCookie, err := req.Cookie("auth")
+	if err != nil {
+		log.Fatal("クッキーの取得に失敗しました: ", err)
+		return
+	}
+
+	client := &client{
+		socket:   socket,
+		send:     make(chan *message, messageBufferSize),
+		room:     r,
+		userData: objx.MustFromBase64(authCookie.Value),
+	}
+
+	r.join <- client
+	defer func() { r.leave <- client }()
+	go client.write()
+	client.read()
+}

--- a/chapter3/chat/room.go
+++ b/chapter3/chat/room.go
@@ -15,14 +15,16 @@ type room struct {
 	leave   chan *client
 	clients map[*client]bool
 	tracer  trace.Tracer
+	avatar  Avatar
 }
 
-func newRoom() *room {
+func newRoom(avatar Avatar) *room {
 	return &room{
 		forward: make(chan *message),
 		join:    make(chan *client),
 		leave:   make(chan *client),
 		clients: make(map[*client]bool),
+		avatar:  avatar,
 	}
 }
 

--- a/chapter3/chat/room.go
+++ b/chapter3/chat/room.go
@@ -18,13 +18,12 @@ type room struct {
 	avatar  Avatar
 }
 
-func newRoom(avatar Avatar) *room {
+func newRoom() *room {
 	return &room{
 		forward: make(chan *message),
 		join:    make(chan *client),
 		leave:   make(chan *client),
 		clients: make(map[*client]bool),
-		avatar:  avatar,
 	}
 }
 

--- a/chapter3/chat/templates/chat.html
+++ b/chapter3/chat/templates/chat.html
@@ -41,6 +41,10 @@
             var msg = JSON.parse(e.data);
             messages.append(
               $("<li>").append(
+                $("<img>").css({
+                  width:50,
+                  verticalAlign:"middle"
+                }).attr("src", msg.AvatarURL),
                 $("<strong>").text(msg.Name + ": "),
                 $("<span>").text(msg.Message)
               )

--- a/chapter3/chat/templates/chat.html
+++ b/chapter3/chat/templates/chat.html
@@ -13,6 +13,7 @@
       {{.UserData.name}}:<br/>
       <textarea></textarea>
       <input type="submit" value="送信" />
+      または <a href="/logout">サインアウト</a>
     </form>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script>

--- a/chapter3/chat/templates/chat.html
+++ b/chapter3/chat/templates/chat.html
@@ -1,0 +1,53 @@
+<html>
+  <head>
+    <title>チャット</title>
+    <style>
+      input { display: block; }
+      ul { list-style: none; }
+    </style>
+  </head>
+  <body>
+    <ul id="messages"></ul>
+    WebSocket を使ったチャットアプリケーション
+    <form id="chatbox">
+      {{.UserData.name}}:<br/>
+      <textarea></textarea>
+      <input type="submit" value="送信" />
+    </form>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script>
+      $(function(){
+        var socket = null;
+        var msgBox = $("#chatbox textarea");
+        var messages = $("#messages");
+        $("#chatbox").submit(function(){
+          if (!msgBox.val()) return false;
+          if (!socket) {
+            alert("エラー : WebSocket接続が行われていません。");
+            return false;
+          }
+          socket.send(JSON.stringify({"Message": msgBox.val()}));
+          msgBox.val("");
+          return false;
+        });
+        if (!window["WebSocket"]) {
+          alert("エラー : WebSocket に対応していないブラウザです。")
+        } else {
+          socket = new WebSocket("ws://{{.Host}}/room");
+          socket.onclose = function() {
+            alert("接続が終了しました。");
+          }
+          socket.onmessage = function(e) {
+            var msg = JSON.parse(e.data);
+            messages.append(
+              $("<li>").append(
+                $("<strong>").text(msg.Name + ": "),
+                $("<span>").text(msg.Message)
+              )
+            );
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/chapter3/chat/templates/chat.html
+++ b/chapter3/chat/templates/chat.html
@@ -1,20 +1,29 @@
 <html>
   <head>
     <title>チャット</title>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
     <style>
-      input { display: block; }
-      ul { list-style: none; }
+      ul#messages { list-style: none; }
+      ul#messages li { margin-bottom: 2px; }
+      ul#messages li img { margin-right: 10px; }
     </style>
   </head>
   <body>
-    <ul id="messages"></ul>
-    WebSocket を使ったチャットアプリケーション
-    <form id="chatbox">
-      {{.UserData.name}}:<br/>
-      <textarea></textarea>
-      <input type="submit" value="送信" />
-      または <a href="/logout">サインアウト</a>
-    </form>
+    <div class="container">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <ul id="messages"></ul>
+        </div>
+      </div>
+      <form id="chatbox" role="form">
+        <div class="form-group">
+          <label for="message">{{.UserData.name}} からメッセージを送信</label>
+          または <a href="/logout">サインアウト</a>
+          <textarea id="message" class="form-control"></textarea>
+        </div>
+        <input type="submit" value="送信" class="btn btn-default" />
+      </form>
+    </div>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script>
       $(function(){
@@ -42,7 +51,7 @@
             var msg = JSON.parse(e.data);
             messages.append(
               $("<li>").append(
-                $("<img>").css({
+                $("<img>").attr("title", msg.Name).css({
                   width:50,
                   verticalAlign:"middle"
                 }).attr("src", msg.AvatarURL),

--- a/chapter3/chat/templates/login.html
+++ b/chapter3/chat/templates/login.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>ログイン</title>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container">
+      <div class="page-header">
+        <h1>サインインしてください</h1>
+      </div>
+      <div class="panel panel-danger">
+        <div class="panel-heading">
+          <h3 class="panel-title">チャットを行うにはサインインが必要です</h3>
+        </div>
+        <div class="panel-body">
+          <p>サインインに使用するサービスを選んでください:</p>
+          <ul>
+            <li><a href="/auth/login/facebook">Facebook</a></li>
+            <li><a href="/auth/login/github">GitHub</a></li>
+            <li><a href="/auth/login/google">Google</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/chapter3/chat/templates/upload.html
+++ b/chapter3/chat/templates/upload.html
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <title>アップロード</title>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container">
+      <div class="page-header">
+        <h1>画像のアップロード</h1>
+      </div>
+      <form role="form" action="/uploader" enctype="multipart/form-data" method="post">
+        <input type="hidden" name="userid" value="{{.UserData.userid}}" />
+        <div class="form-group">
+          <label for="message">ファイルを選択</label>
+          <input type="file" name="avatarFile" />
+        </div>
+        <input type="submit" value="アップロード" class="btn " />
+      </form>
+    </div>
+  </body>
+</html>

--- a/chapter3/chat/upload.go
+++ b/chapter3/chat/upload.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+)
+
+func uploaderHandler(w http.ResponseWriter, req *http.Request) {
+	userId := req.FormValue("userid")
+	file, header, err := req.FormFile("avatarFile")
+	if err != nil {
+		io.WriteString(w, err.Error())
+		return
+	}
+	defer file.Close()
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		io.WriteString(w, err.Error())
+		return
+	}
+	filename := filepath.Join("avatars", userId+filepath.Ext(header.Filename))
+	err = ioutil.WriteFile(filename, data, 0777)
+	if err != nil {
+		io.WriteString(w, err.Error())
+		return
+	}
+	io.WriteString(w, "Success")
+}


### PR DESCRIPTION
## やること
- 認証サービスから追加の情報を取得するための正しい方法。これについては標準規格が定義されていない
- 我々のコードに抽象化を取り入れるべきタイミング
- Go のデータのない型によって節約される処理時間とメモリ消費量
- 既存のインタフェースを再利用し、同じやり方でコレクションや個々のオブジェクトを扱う方法
- Webサービス Gravatar の利用方法
- Go で MD5 アルゴリズムを使ってハッシュ値を算出する方法
- HTTP 経由でファイルをアップロードしてサーバー側に保管する方法
- Go の Web サーバーで静的なファイルを提供する方法
- ユニットテストがコードのリファクタリングを促進するという考え方
- 構造体からインタフェースへと機能を抜き出すべきタイミングと、その方法